### PR TITLE
update version getter

### DIFF
--- a/src/chromepet.js
+++ b/src/chromepet.js
@@ -79,7 +79,7 @@ ChromePet.prototype.stopScraping = function(err, extension) {
 
 ChromePet.prototype._parseExtensionInfo = function(body) {
   var $ = cheerio.load(body);
-  var version = $('meta[itemprop="version"]').attr('content');
+  var version = $('h2:contains("Details")').closest('section').find('li div:contains("Version")').next().text();
   var interactionCount = $('meta[itemprop="interactionCount"]').attr('content');
 
   return {

--- a/src/chromepet.js
+++ b/src/chromepet.js
@@ -74,6 +74,7 @@ ChromePet.prototype.stopScraping = function(err, extension) {
 
   var totalSeconds = this.timer.end();
   this.emitter.emit('end', extension, totalSeconds);
+  this.emitter.removeAllListeners();
 };
 
 


### PR DESCRIPTION
* Replace `$('meta[itemprop="version"]').attr('content')` with the new
method querying the h2 element and finding the version in the next
sibling node of the div with content 'Version'
* Fix end race condition issue